### PR TITLE
Added step in HOW-TO-RUN.md/WIE-LAUFEN.md to login to docker hub account

### DIFF
--- a/HOW-TO-RUN.md
+++ b/HOW-TO-RUN.md
@@ -81,8 +81,10 @@ images and upload them to the public Docker Hub:
 * Create an account at the public
 [Docker Hub](https://hub.docker.com/).
 
-* Set the environment variable `DOCKER_ACCOUNT` to the name of the
-account you just created.
+* Log in to your Docker Hub account by entering `docker login` on the command
+line.
+
+* Set the environment variable `DOCKER_ACCOUNT` to the name of the account.
 
 * Run `docker-build.sh` in the directory
 `microservice-kubernetes-demo`. It builds the images and uploads them to the

--- a/WIE-LAUFEN.md
+++ b/WIE-LAUFEN.md
@@ -94,8 +94,10 @@ Images zu erstellen und sie in den öffentlichen Docker Hub hochzuladen:
 * Erstelle dir einen Account im öffentlichen
 [Docker Hub](https://hub.docker.com/).
 
-* Weise die Umgebungsvariable `DOCKER_ACCOUNT` den Namen des Accounts
-zu, den du gerade erzeugt hast.
+* Logge dich auf der Kommandozeile via `docker login` in deinen erstellten
+Docker Hub Account ein.
+
+* Weise die Umgebungsvariable `DOCKER_ACCOUNT` den Namen des Accounts zu.
 
 * Starte `docker-build.sh` im Verzeichnis
 `microservice-kubernetes-demo`. Es erzeugt die Docker Images und lädt


### PR DESCRIPTION
Wenn man sich tatsächlich im Rahmen des Beispiels erstmalig einen Docker Hub Account anlegt, ist die Wahrscheinlichkeit groß, dass man nicht weiß, wie die Authentifizierung beim pushen (docker-build.sh) funktioniert. Daher wäre ein Hinweis in den Installations-Anleitungen meiner Meinung nach hilfreich.